### PR TITLE
Zk insert link with title

### DIFF
--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -76,9 +76,13 @@ local function insert_link(selected, opts)
 
   local location = util.get_lsp_location_from_selection()
   local selected_text = util.get_text_in_range(util.get_selected_range())
+  local custom_title = ""
 
   if not selected then
     location = util.get_lsp_location_from_caret()
+    if opts["title"] then
+      custom_title = opts["title"]
+    end
   else
     if opts["matchSelected"] then
       opts = vim.tbl_extend("force", { match = { selected_text } }, opts or {})
@@ -89,6 +93,10 @@ local function insert_link(selected, opts)
     assert(note ~= nil, "Picker failed before link insertion: note is nil")
 
     local link_opts = {}
+
+    if selected ~= nil then
+      link_opts.title = custom_title
+    end
 
     if selected and selected_text ~= nil then
       link_opts.title = selected_text

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -94,7 +94,7 @@ local function insert_link(selected, opts)
 
     local link_opts = {}
 
-    if selected ~= nil then
+    if not selected and custom_title ~= "" then
       link_opts.title = custom_title
     end
 


### PR DESCRIPTION
Moving pr here after original repo got archived. 
[original pr](https://github.com/mickael-menu/zk-nvim/pull/156)

In short, allows a title to be passed to `:ZkInsertLink` on execution. Links can then be inserted with custom titles. 
This is instead of writing your text, selecting and then linking the text.