### PR TITLE
Implement zk's append option for link insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,13 @@ see what they can do, and learn as you go.
 
 - `:'<,'>ZkNewFromTitleSelection [{options}]`\
   Creates a new note from the visual selection (used as the **title**) and
-  replaces the selection with a link to the note.
+  replaces the selection with a link to the note (unless `append = true` is
+  passed to options).
 
 - `:'<,'>ZkNewFromContentSelection [{options}]`\
   Creates a new note from the visual selection (used as the **content**) and
-  replaces the selection with a link to the note.
+  replaces the selection with a link to the note (unless `append = true` is
+  passed to options).
 
 ### Navigation
 

--- a/lua/zk/commands/builtin.lua
+++ b/lua/zk/commands/builtin.lua
@@ -17,13 +17,20 @@ commands.add("ZkNew", function(options)
   zk.new(options)
 end)
 
-commands.add("ZkNewFromTitleSelection", function(options)
+local function zk_new_from_selection(kind, options)
   local location = util.get_lsp_location_from_selection()
   local selected_text = util.get_selected_text()
   assert(selected_text ~= nil, "No selected text")
 
   options = options or {}
-  options.title = selected_text
+
+  if kind == "title" then
+    options.title = selected_text
+  elseif kind == "content" then
+    options.content = selected_text
+  else
+    error("Invalid kind: " .. tostring(kind))
+  end
 
   if options.inline == true then
     options.inline = nil
@@ -34,25 +41,14 @@ commands.add("ZkNewFromTitleSelection", function(options)
   end
 
   zk.new(options)
+end
+
+commands.add("ZkNewFromTitleSelection", function(options)
+  zk_new_from_selection("title", options)
 end, { needs_selection = true })
 
 commands.add("ZkNewFromContentSelection", function(options)
-  local location = util.get_lsp_location_from_selection()
-  local selected_text = util.get_selected_text()
-  assert(selected_text ~= nil, "No selected text")
-
-  options = options or {}
-  options.content = selected_text
-
-  if options.inline == true then
-    options.inline = nil
-    options.dryRun = true
-    options.insertContentAtLocation = location
-  else
-    options.insertLinkAtLocation = location
-  end
-
-  zk.new(options)
+  zk_new_from_selection("content", options)
 end, { needs_selection = true })
 
 commands.add("ZkCd", zk.cd)
@@ -81,7 +77,7 @@ local function insert_link(selected, opts)
   opts = vim.tbl_extend("force", {}, opts or {})
 
   local location = util.get_lsp_location_from_selection()
-	local selected_text = ""
+  local selected_text = ""
 
   if not selected then
     location = util.get_lsp_location_from_caret()


### PR DESCRIPTION
Provided #zk-org/724 is merged, this PR will implement it in `ZkNewFrom...`
functions.

Selecting text, then executing
`ZkNewFrom[Content|Title]Selection {append = true}` will append the resultant
link instead of replacing the selected text with it.
